### PR TITLE
Metadata performance

### DIFF
--- a/DataverseFormatChanger/DataverseFormatChangerTool/DataverseFormatChangerToolPluginControl.cs
+++ b/DataverseFormatChanger/DataverseFormatChangerTool/DataverseFormatChangerToolPluginControl.cs
@@ -100,6 +100,7 @@ namespace DataverseFormatChangerTool
                         {
                             var metadataCache = ConnectionDetail.MetadataCacheLoader.ConfigureAwait(false).GetAwaiter().GetResult();
                             args.Result = metadataCache.EntityMetadata;
+                            return;
                         }
                         catch
                         {


### PR DESCRIPTION
Use the XTB shared metadata cache where possible. If it's not available or fails, load the metadata using a more targeted query to only retrieve the required properties and only for string attributes.